### PR TITLE
Update script to install node v18 [GDS-1942]

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Joel Kesler / Vendasta Technologies
+Copyright (c) 2023 Joel Kesler / Vendasta Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Joel Kesler / Vendasta Technologies
+Copyright (c) 2021 Joel Kesler / Vendasta Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ nvm install 14      # or 10.10.0, 8.9.1, etc
 **Upgrading Node and NPM**\
 There is a handy command in your `.bash_profile` and `.zsh_profile` that will automatically upgrade to the latest version of Node 18 and NPM, plus it will re-install any global packages you have installed so you do not have to manually do it each time. Read more about it [here](https://vendasta.jira.com/wiki/spaces/RD/pages/212172883/Tips+and+Tricks#Easily-Update-Node-and-NPM-(using-NVM)-Terminal)
 ```sh
-node-upgrade        # update node 18 and reinstall all global packages
+node-upgrade 18        # update node 18 and reinstall all global packages
 ```
 
 <br>
@@ -205,11 +205,13 @@ export NVM_DIR="$HOME/.nvm"
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
 export NODE_OPTIONS=--max_old_space_size=8192
 
-# Update Node lts and reinstall previous packages
+# Update Node to selected version and reinstall previous packages
 node-upgrade() {
+    new_version=${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
     prev_ver=$(nvm current)
-    nvm install 18
+    nvm install "$new_version"
     nvm reinstall-packages "$prev_ver"
+    nvm alias default "$new_version"
     # nvm uninstall "$prev_ver"
     nvm cache clear
 }
@@ -271,11 +273,13 @@ export NVM_DIR="$HOME/.nvm"
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
 export NODE_OPTIONS=--max_old_space_size=8192
 
-# Update Node lts and reinstall previous packages
+# Update Node to selected version and reinstall previous packages
 node-upgrade() {
+    readonly new_version=${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
     prev_ver=$(nvm current)
-    nvm install 18
+    nvm install "$new_version"
     nvm reinstall-packages "$prev_ver"
+    nvm alias default "$new_version"
     # nvm uninstall "$prev_ver"
     nvm cache clear
 }

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ As Mac OS has recently removed the bundled copy of Python 2.7, please see [this 
 
 **Installing Node versions**\
 Use nvm to install and upgrade different versions of Node. [Official docs][nvm docs] \
-We use the Node v16 at Vendasta.
+We use the Node v18 at Vendasta.
 ```sh
-# Install the latest version of Node 16 with NPM
-nvm install 16
+# Install the latest version of Node 18 with NPM
+nvm install 18
 
 # Install a specific version of Node
 nvm install 14      # or 10.10.0, 8.9.1, etc
@@ -96,9 +96,9 @@ nvm install 14      # or 10.10.0, 8.9.1, etc
 <br>
 
 **Upgrading Node and NPM**\
-There is a handy command in your `.bash_profile` and `.zsh_profile` that will automatically upgrade to the latest version of Node 16 and NPM, plus it will re-install any global packages you have installed so you do not have to manually do it each time. Read more about it [here](https://vendasta.jira.com/wiki/spaces/RD/pages/212172883/Tips+and+Tricks#Easily-Update-Node-and-NPM-(using-NVM)-Terminal)
+There is a handy command in your `.bash_profile` and `.zsh_profile` that will automatically upgrade to the latest version of Node 18 and NPM, plus it will re-install any global packages you have installed so you do not have to manually do it each time. Read more about it [here](https://vendasta.jira.com/wiki/spaces/RD/pages/212172883/Tips+and+Tricks#Easily-Update-Node-and-NPM-(using-NVM)-Terminal)
 ```sh
-node-upgrade        # update node 16 and reinstall all global packages
+node-upgrade        # update node 18 and reinstall all global packages
 ```
 
 <br>
@@ -208,7 +208,7 @@ export NODE_OPTIONS=--max_old_space_size=8192
 # Update Node lts and reinstall previous packages
 node-upgrade() {
     prev_ver=$(nvm current)
-    nvm install 16
+    nvm install 18
     nvm reinstall-packages "$prev_ver"
     # nvm uninstall "$prev_ver"
     nvm cache clear
@@ -274,7 +274,7 @@ export NODE_OPTIONS=--max_old_space_size=8192
 # Update Node lts and reinstall previous packages
 node-upgrade() {
     prev_ver=$(nvm current)
-    nvm install 16
+    nvm install 18
     nvm reinstall-packages "$prev_ver"
     # nvm uninstall "$prev_ver"
     nvm cache clear
@@ -364,7 +364,7 @@ getLastestNVM() {
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/$(getLastestNVM)/install.sh | bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-nvm install 16
+nvm install 18
 npm install --location=global @angular/cli
 npm install --location=global nx
 npm install --location=global husky
@@ -719,7 +719,7 @@ This script helps new developers at Vendasta setup their laptops quicker, lettin
 I have tried to make this script simple and useful. You will want to customize the installation and configuration to match the tools and services you use at your company.
 	   
 - At Vendasta, we are using Go, Angular, and Google Cloud. You most likely do not use all of these, so remove, change, and tweak to meet your needs.
-- We lock our Node version at 16 (using NVM) for best compatibility with Angular and NX. You will likely want to change this. 
+- We lock our Node version at 18 (using NVM) for best compatibility with Angular and NX. You will likely want to change this. 
 - To customize the [welcome logo](https://github.com/vendasta/setup-new-computer-script/blob/47b7c97f21b293e143a0566cafecec2cfc69c528/setup-new-computer.sh#L74-L90) and add a bit of style, I used the handy [Text to ASCII Art Generator](https://patorjk.com/software/taag/#p=testall&f=Isometric1&t=Vendasta)
 - When you update the script, remember to update the readme "What's Installed" section too
 - Be sure to update both the `.bash_profile` and `.zprofile`

--- a/README.md
+++ b/README.md
@@ -208,9 +208,7 @@ export NODE_OPTIONS=--max_old_space_size=12000
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {
     new_version=${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
-    prev_ver=$(nvm current)
-    nvm install "$new_version"
-    nvm reinstall-packages "$prev_ver"
+    nvm install "$new_version" --reinstall-packages-from=current
     nvm alias default "$new_version"
     # nvm uninstall "$prev_ver"
     nvm cache clear
@@ -276,9 +274,7 @@ export NODE_OPTIONS=--max_old_space_size=12000
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {
     readonly new_version=${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
-    prev_ver=$(nvm current)
-    nvm install "$new_version"
-    nvm reinstall-packages "$prev_ver"
+    nvm install "$new_version" --reinstall-packages-from=current
     nvm alias default "$new_version"
     # nvm uninstall "$prev_ver"
     nvm cache clear

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ export NVM_DIR="$HOME/.nvm"
 
 # Node
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
-export NODE_OPTIONS=--max_old_space_size=8192
+export NODE_OPTIONS=--max_old_space_size=12000
 
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {
@@ -271,7 +271,7 @@ export NVM_DIR="$HOME/.nvm"
 
 # Node
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
-export NODE_OPTIONS=--max_old_space_size=8192
+export NODE_OPTIONS=--max_old_space_size=12000
 
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -157,7 +157,7 @@ export NVM_DIR="\$HOME/.nvm"
 
 # Node
 # Increases the default memory limit for Node, so larger Angular projects can be built
-export NODE_OPTIONS=--max_old_space_size=8192
+export NODE_OPTIONS=--max_old_space_size=12000
 
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {
@@ -230,7 +230,7 @@ export NVM_DIR="\$HOME/.nvm"
 
 # Node
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
-export NODE_OPTIONS=--max_old_space_size=8192
+export NODE_OPTIONS=--max_old_space_size=12000
 
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -162,9 +162,7 @@ export NODE_OPTIONS=--max_old_space_size=12000
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {
     new_version=\${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
-    prev_ver=\$(nvm current)
-    nvm install "\$new_version"
-    nvm reinstall-packages "\$prev_ver"
+    nvm install "\$new_version" --reinstall-packages-from=current
     nvm alias default "\$new_version"
     # nvm uninstall "\$prev_ver"
     nvm cache clear
@@ -235,9 +233,7 @@ export NODE_OPTIONS=--max_old_space_size=12000
 # Update Node to selected version and reinstall previous packages
 node-upgrade() {
     readonly new_version=\${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
-    prev_ver=\$(nvm current)
-    nvm install "\$new_version"
-    nvm reinstall-packages "\$prev_ver"
+    nvm install "\$new_version" --reinstall-packages-from=current
     nvm alias default "\$new_version"
     # nvm uninstall "\$prev_ver"
     nvm cache clear

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="v3.1.0"
+VERSION="v3.2.0"
 #===============================================================================
 # title           setup-new-computer.sh
 # author          Joel Kesler 

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -159,11 +159,13 @@ export NVM_DIR="\$HOME/.nvm"
 # Increases the default memory limit for Node, so larger Angular projects can be built
 export NODE_OPTIONS=--max_old_space_size=8192
 
-# Update Node 18 and reinstall previous packages
+# Update Node to selected version and reinstall previous packages
 node-upgrade() {
+    new_version=\${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
     prev_ver=\$(nvm current)
-    nvm install 18
+    nvm install "\$new_version"
     nvm reinstall-packages "\$prev_ver"
+    nvm alias default "\$new_version"
     # nvm uninstall "\$prev_ver"
     nvm cache clear
 }
@@ -230,11 +232,13 @@ export NVM_DIR="\$HOME/.nvm"
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
 export NODE_OPTIONS=--max_old_space_size=8192
 
-# Update Node 18 and reinstall previous packages
+# Update Node to selected version and reinstall previous packages
 node-upgrade() {
+    readonly new_version=\${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
     prev_ver=\$(nvm current)
-    nvm install 18
+    nvm install "\$new_version"
     nvm reinstall-packages "\$prev_ver"
+    nvm alias default "\$new_version"
     # nvm uninstall "\$prev_ver"
     nvm cache clear
 }

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="v3.0.1"
+VERSION="v3.1.0"
 #===============================================================================
 # title           setup-new-computer.sh
 # author          Joel Kesler 
@@ -159,10 +159,10 @@ export NVM_DIR="\$HOME/.nvm"
 # Increases the default memory limit for Node, so larger Angular projects can be built
 export NODE_OPTIONS=--max_old_space_size=8192
 
-# Update Node 16 and reinstall previous packages
+# Update Node 18 and reinstall previous packages
 node-upgrade() {
     prev_ver=\$(nvm current)
-    nvm install 16
+    nvm install 18
     nvm reinstall-packages "\$prev_ver"
     # nvm uninstall "\$prev_ver"
     nvm cache clear
@@ -230,10 +230,10 @@ export NVM_DIR="\$HOME/.nvm"
 # Increases the default memory limit for Node, so larger Anglar prjects can be built
 export NODE_OPTIONS=--max_old_space_size=8192
 
-# Update Node 16 and reinstall previous packages
+# Update Node 18 and reinstall previous packages
 node-upgrade() {
     prev_ver=\$(nvm current)
-    nvm install 16
+    nvm install 18
     nvm reinstall-packages "\$prev_ver"
     # nvm uninstall "\$prev_ver"
     nvm cache clear
@@ -487,7 +487,7 @@ printHeading "Installing Node and Angular CLI through NVM"
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
     printDivider
         echo "Installing Node..."
-        nvm install 16
+        nvm install 18
     printStep "Angular CLI"             "npm install --location=global @angular/cli"
     printStep "NX"                      "npm install --location=global nx"
     printStep "Husky"                   "npm install --location=global husky"


### PR DESCRIPTION
Node v18 is the current LTS release and Angular and NX are updated to support it.

I also improved the `node-upgrade` utility. You now can pass in the version you want to upgrade to, instead of manually needing to modify the utility itself:

```shell

# Update Node to selected version and reinstall previous packages
node-upgrade() {
    new_version=${1:?"Please specify a version to upgrade to. Example: node-upgrade 18"}
    prev_ver=$(nvm current)
    nvm install "$new_version"
    nvm reinstall-packages "$prev_ver"
    nvm alias default "$new_version"
    # nvm uninstall "$prev_ver"
    nvm cache clear
}
```
