### PR TITLE
Replace Slack with Google Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,10 +422,10 @@ gcloud components install docker-credential-gcr --quiet
 ### Applications
 
 <details>
-  <summary>Slack</summary>
+  <summary>Google Chat</summary>
   
 ```sh
-brew install --cask slack
+brew install --cask google-chat
 ```
 </details>
 

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -388,11 +388,11 @@ printDivider
 # Install  Apps
 printHeading "Installing Applications"
 
-    if [[ -d "/Applications/Slack.app" ]]; then
+    if [[ -d "/Applications/Chat.app" ]]; then
         printDivider
-        echo "✔ Slack already installed. Skipping"
+        echo "✔ Google Chat already installed. Skipping"
     else
-        printStep "Slack"                     "brew install --cask slack"
+        printStep "Google Chat"                     "brew install --cask google-chat"
     fi
 
     if [[ -d "/Applications/Firefox.app" ]]; then


### PR DESCRIPTION
# Purpose
This PR intends to replace Slack with Google Chat as the program getting installed during dev MacBook setup. I do not know if we want to keep it as an install (and have both programs installed during setup) during this transitory period, but I took the liberty of assuming that we do not want to do that for new developers.

## Implementation
It does this by replacing the Slack references with the appropriate Google Chat ones.

I referenced this for determining install location
https://github.com/Homebrew/homebrew-cask/blob/82cb0fd9ac901f628c309be45fc20d8aef673618/Casks/g/google-chat.rb

## Proof
![05952139-EA95-4CF2-9160-2D3D40C811D7_1_201_a](https://github.com/vendasta/setup-new-computer-script/assets/135864700/f4bd31e2-6b23-422e-9d6d-30429c2e1c1b)
