### PR TITLE
Replace Docker with Rancher

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,10 +440,10 @@ brew install --cask google-chrome
 
 
 <details>
-  <summary>Docker for Mac</summary>
+  <summary>Rancher Desktop (Docker Desktop alternative)</summary>
 
 ```sh
-brew install --cask docker
+brew install --cask rancher
 ```
 </details>
 

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -404,9 +404,15 @@ printHeading "Installing Applications"
 
     if [[ -d "/Applications/Docker.app" ]]; then
         printDivider
-        echo "✔ Docker already installed. Skipping"
+        printStep "Uninstall Docker desktop for Mac"              "brew uninstall --cask docker"
+        echo ""
+    fi
+
+    if [[ -d "/Applications/Rancher Desktop.app" ]]; then
+            printDivider
+            echo "✔ Rancher already installed. Skipping"
     else
-        printStep "Docker for Mac"              "brew install --cask docker"
+        printStep "Rancher Desktop (Docker Desktop alternative)"              "brew install --cask rancher"
     fi
 
     if [[ -d "/Applications/Postman.app" ]]; then


### PR DESCRIPTION
Docker changed their license and now requires payment for use by companies over 250 employees. Vendasta has decided to switch to Rancher Desktop which is an open source alternative. It is a drop in replacement for Docker Desktop. https://rancherdesktop.io/

@dbobryk @joelkesler 