### PR TITLE
chore: Update node sass command to use "sass" instead of "node-sass"

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ node-upgrade() {
 
 
 <details>
-  <summary>Node (from nvm, with npm, nx, husky, Angular CLI, Node-Sass, and Node-Gyp)</summary>
+  <summary>Node (from nvm, with npm, nx, husky, Angular CLI, Sass, and Node-Gyp)</summary>
   
 ```sh
 getLastestNVM() {
@@ -363,7 +363,7 @@ nvm install 20
 npm install --location=global @angular/cli
 npm install --location=global nx
 npm install --location=global husky
-npm install --location=global node-sass
+npm install --location=global sass
 npm install --location=global node-gyp
 ```
   We will also create a new file called `~/.huskyrc` and fill it with:

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -490,7 +490,7 @@ printHeading "Installing Node and Angular CLI through NVM"
     printStep "Angular CLI"             "npm install --location=global @angular/cli"
     printStep "NX"                      "npm install --location=global nx"
     printStep "Husky"                   "npm install --location=global husky"
-    printStep "Node Sass"               "npm install --location=global node-sass"
+    printStep "Node Sass"               "npm install --location=global sass"
     printStep "Node Gyp"                "npm install --location=global node-gyp"
     printDivider
         echo "✔ Touch ~/.huskyrc"


### PR DESCRIPTION
### Purpose
The [node-scss](https://github.com/sass/node-sass) package had a complete depreciation in July. As a result, the setup script is returning an error.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/6bf0a70f-2b48-4b38-9731-da32f9efe4a6">


**Depreciation notice** - [Link](https://sass-lang.com/blog/libsass-is-deprecated/#:~:text=If%20you%E2%80%99re%20a%20user%20of%20Node%20Sass%2C%20migrating%20to%20Dart%20Sass%20is%20straightforward%3A%20just%20replace%20node%2Dsass%20in%20your%20package.json%20file%20with%20sass.%20Both%20packages%20expose%20the%20same%20JavaScript%C2%A0API.)
The proper alternative for that outdated package is to use [scss](https://github.com/sass/sass). sass package is also expose the same JavaScript API.

### Explanation of the approach 

- Swap out node-scss with scss in the installation command
