### PR TITLE
[FIX] Updating deprecated husky location

### DIFF
--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -493,6 +493,9 @@ printHeading "Installing Node and Angular CLI through NVM"
     printStep "Node Sass"               "npm install --location=global sass"
     printStep "Node Gyp"                "npm install --location=global node-gyp"
     printDivider
+        echo "✔ Ensure ~/.config/husky directory exists"
+            mkdir -p ~/.config/husky
+    printDivider
         echo "✔ Touch ~/.config/husky/init.sh"
             touch ~/.config/husky/init.sh
     printDivider

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -248,8 +248,8 @@ EOT
 }
 
 
-writetoHuskrc() {
-cat << EOT >> ~/.huskyrc
+writetoHuskyInit() {
+cat << EOT >> ~/.config/husky/init.sh
 
 
 # --------------------------------------------------------------------
@@ -493,15 +493,15 @@ printHeading "Installing Node and Angular CLI through NVM"
     printStep "Node Sass"               "npm install --location=global sass"
     printStep "Node Gyp"                "npm install --location=global node-gyp"
     printDivider
-        echo "✔ Touch ~/.huskyrc"
-            touch ~/.huskyrc
+        echo "✔ Touch ~/.config/husky/init.sh"
+            touch ~/.config/husky/init.sh
     printDivider
         # Husky profile
-        if grep --quiet "nvm" ~/.huskyrc; then
-            echo "✔ .huskyrc already includes nvm. Skipping"
+        if grep --quiet "nvm" ~/.config/husky/init.sh; then
+            echo "✔ ~/.config/husky/init.sh already includes nvm. Skipping"
         else
-            writetoHuskrc
-            echo "✔ Add nvm to .huskyrc"
+            writetoHuskyInit
+            echo "✔ Add nvm to ~/.config/husky/init.sh"
         fi
 printDivider
 


### PR DESCRIPTION
## Problem

I've been experiencing issues while running the pre-commit hook in the Galaxy Repo.
Husky is deprecating the usage of the route `~/.huskyrc`
They are suggesting the usage of a new route.

## Solution
Owners are suggesting to stop using the route I mentioned before and using `~/.config/husky/init.sh` instead
https://github.com/typicode/husky/blob/a2d942a670b3d6a04578005a0fd2dc310e511849/husky#L9

After implementing these changes everything is working smoothly.
These alerts started being announced since the v8.

![image](https://github.com/user-attachments/assets/6d44e9a4-2ec0-4162-ab98-8c9e62b16b74)


### References
https://typicode.github.io/husky/how-to.html#startup-files
https://typicode.github.io/husky/how-to.html#solution

## Proof
<img width="386" alt="image" src="https://github.com/user-attachments/assets/1198145a-f7a5-4881-a570-fa26b3976666">

