### PR TITLE
Add missing steps from the getting started guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ After you have run the script, please complete the following steps to finish set
    
    [nextsteps]: https://vendasta.jira.com/wiki/spaces/RD/pages/199032984/Onboarding+New+Developers#New-Dev%5BhardBreak%5DSetup-New-Developer%E2%80%99s-Computer-with-a-script
 
+3. **Google Cloud SDK authentication and Kubernetes context**\
+   The setup script runs these at the end. If you skipped them or need to re-run:
+   ```sh
+   gcloud auth login
+   gcloud auth application-default login
+   gcloud auth configure-docker
+   kubectl config set-context gke_repcore-prod_us-central1_vendasta-central
+   gcloud beta container clusters get-credentials vendasta-central --region us-central1 --project repcore-prod
+   gcloud auth print-identity-token
+   ```
+
+4. **Install MSCLI (Vendasta)**\
+   The setup script installs MSCLI and then prompts for auth at the end. If you skipped them or need to re-run:
+   ```sh
+   go install github.com/vendasta/mscli@latest
+   mscli auth login -e demo
+   mscli auth login -e prod
+   ```
+   See the MSCLI installation docs for more details:
+   - https://github.com/vendasta/mscli#installation-and-updating
+
 <br><br>
 
 
@@ -331,6 +352,16 @@ node-upgrade() {
    ```
 </details>
 
+<details>
+  <summary>MSCLI (Vendasta)</summary>
+
+```sh
+go install github.com/vendasta/mscli@latest
+mscli auth login -e demo
+mscli auth login -e prod
+```
+</details>
+
  
  
  ### Languages
@@ -415,6 +446,19 @@ gcloud components install app-engine-python --quiet
 gcloud components install app-engine-python-extras --quiet
 gcloud components install kubectl --quiet
 gcloud components install docker-credential-gcr --quiet
+```
+</details>
+
+<details>
+  <summary>Google Cloud authentication and Kubernetes context</summary>
+
+```sh
+gcloud auth login
+gcloud auth application-default login
+gcloud auth configure-docker
+kubectl config set-context gke_repcore-prod_us-central1_vendasta-central
+gcloud beta container clusters get-credentials vendasta-central --region us-central1 --project repcore-prod
+gcloud auth print-identity-token
 ```
 </details>
 

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -382,6 +382,7 @@ printHeading "Installing Brew Packages"
     printStep "zsh-completions"             "brew install zsh-completions"
     printStep "Ruby"                        "brew install ruby"
     printStep "Git"                         "brew install git"
+    printStep "GitHub CLI"                  "brew install gh"
 printDivider
 
 
@@ -636,6 +637,34 @@ printDivider
         ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 printDivider
 
+
+# Install Vendasta MSCLI
+printHeading "Installing Vendasta MSCLI"
+    printDivider
+    printStep "MSCLI"                       "go install github.com/vendasta/mscli@latest"
+printDivider
+
+
+
+# Authenticate (deferred to end)
+printHeading "Authenticate Services"
+    printDivider
+    printStep "Google Cloud Login"          "gcloud auth login"
+    printDivider
+    printStep "Google Cloud ADC Login"      "gcloud auth application-default login"
+    printDivider
+    printStep "Google Cloud Docker Auth"    "gcloud auth configure-docker"
+    printDivider
+    printStep "Set Kubernetes Context"      "kubectl config set-context gke_repcore-prod_us-central1_vendasta-central"
+    printDivider
+    printStep "Get GKE Credentials"         "gcloud beta container clusters get-credentials vendasta-central --region us-central1 --project repcore-prod"
+    printDivider
+    printStep "Verify Google Cloud Auth"    "gcloud auth print-identity-token"
+    printDivider
+    printStep "MSCLI Login (Demo)"          "mscli auth login -e demo"
+    printDivider
+    printStep "MSCLI Login (Prod)"          "mscli auth login -e prod"
+printDivider
 
 
 #===============================================================================


### PR DESCRIPTION
I had AI review @dhopkins-va's [Citizen Developer Laptop Setup Guide](https://vendasta.jira.com/wiki/spaces/RD/blog/2026/01/18/3813900499/Citizen+Developer+Laptop+Setup+Guide) as well as the [new dev setup guide](https://vendasta.jira.com/wiki/spaces/RD/pages/199032984/Setting+Up+New+Developer+Computers) for parts that can be added to this script. 

The GitHub CLI is the only new tool. The other changes are automating some of the manual login commands. 

We could potentially add something to initialize defaults in the `~/.cursor` and `~/.claud` directories but I think it will be replaced with an admin enabled link to https://github.com/vendasta/dev-agent-toolkit soon. For now I created a soft link from my git checkout to the cursor directory (`ln -s ~/ai-tools/dev-agent-toolkit/skills ~/.cursor/skills`)

@vendasta/staff-devs 