### PR TITLE
Switch kubectl setup to Connect Gateway for vendasta-central

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ gcloud components install app-engine-go --quiet
 gcloud components install app-engine-python --quiet
 gcloud components install app-engine-python-extras --quiet
 gcloud components install kubectl --quiet
+gcloud components install gke-gcloud-auth-plugin --quiet
 gcloud components install docker-credential-gcr --quiet
 ```
 </details>

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ After you have run the script, please complete the following steps to finish set
    gcloud auth login
    gcloud auth application-default login
    gcloud auth configure-docker
-   kubectl config set-context gke_repcore-prod_us-central1_vendasta-central
-   gcloud beta container clusters get-credentials vendasta-central --region us-central1 --project repcore-prod
+   gcloud container fleet memberships get-credentials vendasta-central --project=repcore-prod
    gcloud auth print-identity-token
    ```
 
@@ -456,8 +455,7 @@ gcloud components install docker-credential-gcr --quiet
 gcloud auth login
 gcloud auth application-default login
 gcloud auth configure-docker
-kubectl config set-context gke_repcore-prod_us-central1_vendasta-central
-gcloud beta container clusters get-credentials vendasta-central --region us-central1 --project repcore-prod
+gcloud container fleet memberships get-credentials vendasta-central --project=repcore-prod
 gcloud auth print-identity-token
 ```
 </details>

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -534,6 +534,7 @@ printHeading "Install Google Cloud SDK and Components"
     printStep "App Engine - Python"         "gcloud components install app-engine-python --quiet"
     printStep "App Engine - Python Extras"  "gcloud components install app-engine-python-extras --quiet"
     printStep "Kubectl"                     "gcloud components install kubectl --quiet"
+    printStep "GKE Auth Plugin"             "gcloud components install gke-gcloud-auth-plugin --quiet"
     printStep "Docker Credentials"          "gcloud components install docker-credential-gcr --quiet"
 printDivider
 

--- a/setup-new-computer.sh
+++ b/setup-new-computer.sh
@@ -655,9 +655,7 @@ printHeading "Authenticate Services"
     printDivider
     printStep "Google Cloud Docker Auth"    "gcloud auth configure-docker"
     printDivider
-    printStep "Set Kubernetes Context"      "kubectl config set-context gke_repcore-prod_us-central1_vendasta-central"
-    printDivider
-    printStep "Get GKE Credentials"         "gcloud beta container clusters get-credentials vendasta-central --region us-central1 --project repcore-prod"
+    printStep "Get Connect Gateway Credentials" "gcloud container fleet memberships get-credentials vendasta-central --project=repcore-prod"
     printDivider
     printStep "Verify Google Cloud Auth"    "gcloud auth print-identity-token"
     printDivider


### PR DESCRIPTION
## Summary
- The `vendasta-central` cluster's public Kubernetes API endpoint is being disabled, so the direct `gke_repcore-prod_us-central1_vendasta-central` context will stop working.
- Replace the two-step `kubectl config set-context gke_…` + `gcloud beta container clusters get-credentials …` flow with the single Connect Gateway command: `gcloud container fleet memberships get-credentials vendasta-central --project=repcore-prod`.
- Updated both `setup-new-computer.sh` and `README.md` (both the "if you skipped them" snippet and the collapsed Google Cloud auth section).

## Test plan
- [ ] Run the updated auth section of `setup-new-computer.sh` on a fresh-ish machine and verify `kubectl get pod -n mission-control-prod` works against `vendasta-central`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)